### PR TITLE
DM-40606: Change exits to throws.

### DIFF
--- a/src/subs/FitSubroutines.cpp
+++ b/src/subs/FitSubroutines.cpp
@@ -1577,7 +1577,7 @@ void readObjects_oneExtension(const vector<unique_ptr<Exposure>> &exposures, int
     if (fieldProjection) delete fieldProjection;
 
     if (!extn.keepers.empty()) {
-        throw std::runtime_error("Did not find all desired objects extension " + iext);
+        throw std::runtime_error("Did not find all desired objects extension " + std::to_string(iext));
     }
 }
 

--- a/src/subs/MapDegeneracies.cpp
+++ b/src/subs/MapDegeneracies.cpp
@@ -116,7 +116,7 @@ list<set<int>> MapDegeneracies<S>::initializationOrder() {
             // We have maps with no clear degeneracy breaking path.
             cerr << "ERROR: no path to initialize these maps without degeneracies:" << endl;
             for (auto &m : maps) cerr << "  " << m.first << endl;
-            exit(1);
+            throw std::runtime_error("Maps cannot be initialized due to degeneracies.");
         }
 
         // Do everything that can be done - for a given choose all relevant exposures in

--- a/src/subs/Match.cpp
+++ b/src/subs/Match.cpp
@@ -1197,7 +1197,8 @@ double CoordAlign::fitOnce(bool reportToCerr, bool inPlace) {
             for (int i = 0; i < N; i++) {
                 if (alpha(i, i) < 0.) {
                     cerr << "Negative alpha diagonal " << alpha(i, i) << " at " << i << endl;
-                    exit(1);
+                    throw std::runtime_error("Negative alpha diagonal " + std::to_string(alpha(i, i))
+                                             + " at " + std::to_string(i));
                 }
                 if (alpha(i, i) > 0.) ss[i] = 1. / sqrt(alpha(i, i));
                 // Scale row / col of lower triangle, hitting diagonal twice
@@ -1241,8 +1242,7 @@ double CoordAlign::fitOnce(bool reportToCerr, bool inPlace) {
         if (choleskyFails) {
             cerr << "Caught exception during Cholesky" << endl;
             if (inPlace) {
-                cerr << "Cannot describe degeneracies while dividing in place" << endl;
-                exit(1);
+                throw std::runtime_error("Cannot describe degeneracies while dividing in place");
             }
             int N = alpha.cols();
             set<int> degen;
@@ -1308,7 +1308,7 @@ double CoordAlign::fitOnce(bool reportToCerr, bool inPlace) {
                          << j - startIndex << " of " << nParams << endl;
                 }
             }
-            exit(1);
+            throw std::runtime_error("Cholesky decomposition failed");
         }
 
         // Now attempt Newton iterations to solution, with fixed alpha

--- a/src/subs/WcsSubs.cpp
+++ b/src/subs/WcsSubs.cpp
@@ -253,9 +253,8 @@ list<int> pickExposuresToInitialize(const vector<unique_ptr<Instrument>> &instru
                     // maps, then enter this dependence into our sets
                     exposuresUsingDevice[iDev].insert(iExpo);
                     if (unusedExposures.count(iExpo) > 0 || unusedDevices.count(iDev) > 0) {
-                        cerr << "Logic problem: extension map " << extnptr->mapName
-                             << " is using allegedly unused exposure or device map" << endl;
-                        exit(1);
+                        throw std::runtime_error("Logic problem: extension map " + extnptr->mapName
+                                                 + " is using allegedly unused exposure or device map");
                     }
                 }
             }
@@ -280,11 +279,11 @@ list<int> pickExposuresToInitialize(const vector<unique_ptr<Instrument>> &instru
         }
 
         if (exposureForInitializing < 0) {
-            cerr << "Could not find an exposure that can initialize defaulted devices \n"
-                 << "for instrument " << instr.name << endl;
-            cerr << "Write more code if you want to exploit more complex situations \n"
-                 << "where some non-defaulted devices can initialize a defaulted exposure." << endl;
-            exit(1);
+            std::string error_message = ("Could not find an exposure that can initialize defaulted devices \n"
+                                         "for instrument " + instr.name + "\nWrite more code if you want to"
+                                         " exploit more complex situations where some non-defaulted devices"
+                                         " can initialize a defaulted exposure.");
+            throw std::runtime_error(error_message);
         } else {
             exposuresToInitialize.push_back(exposureForInitializing);
             cerr << "Using exposure " << exposures[exposureForInitializing]->name


### PR DESCRIPTION
This also removes the try/catch statement in `WCSFit::fit()`, which was turning any error into a `exit(1)`.