### PR TITLE
DM-41635: Add method to output model uncertainty

### DIFF
--- a/include/Match.h
+++ b/include/Match.h
@@ -330,6 +330,9 @@ public:
     double fitOnce(bool reportToCerr = true,
                    bool inPlace = false,  // Set inPlace to save space, but can't debug singularities
                    bool doSVD = false);  
+    // Calculate the inverse of the alpha matrix, which will be the covariance
+    // of the fit parameters.
+    DMatrix calculateAlphaInv();
     // Conduct one round of sigma-clipping.  If doReserved=true,
     // then only clip reserved Matches.  If =false, then
     // only clip non-reserved Matches.

--- a/include/WCSFitRoutine.h
+++ b/include/WCSFitRoutine.h
@@ -89,6 +89,8 @@ public:
     Astro::StarCatalog getStarCatalog();
 
     void saveResults(std::string outWcs, std::string outCatalog, std::string starCatalog);
+
+    astrometry::DMatrix getModelCovariance();
 };
 
 #endif

--- a/pydir/wcsfit.cpp
+++ b/pydir/wcsfit.cpp
@@ -257,6 +257,7 @@ PYBIND11_MODULE(wcsfit, m) {
                     result["starInvCov"] = vectorToNumpy(starCat.starInvCov);
                     return result;
             })
+            .def("getModelCovariance", &WCSFit::getModelCovariance)
             .def_readonly("mapCollection", &WCSFit::mapCollection);
 
     ///////////// Friends of Friends Fitting Class //////////////////

--- a/src/subs/WCSFitRoutine.cpp
+++ b/src/subs/WCSFitRoutine.cpp
@@ -591,3 +591,11 @@ void WCSFit::saveResults(std::string outWcs, std::string outCatalog, std::string
         Astro::saveResults(matches, outCatalog, starCatalog, extensionProjections);
     }
 }
+
+astrometry::DMatrix WCSFit::getModelCovariance() {
+
+    astrometry::CoordAlign ca(mapCollection, matches);
+    astrometry::DMatrix modelCov = ca.calculateAlphaInv();
+    return modelCov;
+
+}


### PR DESCRIPTION
The added function, `CoordAlign::calculateAlphaInv()` is based on what is done in the first 60 lines of the `CoordAlign::fitOnce` function, with the addition of calculating the inverse of the alpha matrix at the end.