### PR TITLE
DM-42147: Add needed array include.

### DIFF
--- a/include/FoF.h
+++ b/include/FoF.h
@@ -6,6 +6,7 @@
 #ifndef FOF_N
 #define FOF_N
 
+#include <array>
 #include <list>
 #include <set>
 #include <vector>


### PR DESCRIPTION
Newer compilers seem to be picky about requiring `#include <array>` in order to access `std::array`.