### PR TITLE
DM-45226: Replace in1d with isin

### DIFF
--- a/analysis/photoplots.py
+++ b/analysis/photoplots.py
@@ -719,7 +719,7 @@ def pixelPhase(fitsfile, device='', nphase=20, plotRMS=False, maxSigma=0.006,
 
         #Now select points from one of the extensions for this device.
         extn = data['Extension'][use]
-        use = np.in1d(extn, useExtensions)
+        use = np.isin(extn, useExtensions)
         print('points in: ', len(use), ' chosen ', np.count_nonzero(use))
         xPix = xPix[use]
         yPix = yPix[use]


### PR DESCRIPTION
The former is no longer supported on numpy 2.x

@cmsaunders I'm not sure if the analysis directory is even used by us. Also, in1d always returns 1D but isin returns the shape of the original, so I'm not even sure if this is a suitable fix.