### PR TITLE
DM-51138: WCSFit: add rejection off-ramp

### DIFF
--- a/include/WCSFitRoutine.h
+++ b/include/WCSFitRoutine.h
@@ -83,7 +83,8 @@ public:
     void fit(double maxError = 100., int minFitExposures = 200, double reserveFraction = 0.2,
              int randomNumberSeed = 1234, double minimumImprovement = 0.02, double clipThresh = 5.0,
              double chisqTolerance = 0.001, bool clipEntireMatch = false, bool divideInPlace = false,
-             bool purgeOutput = false, double minColor = -10.0, double maxColor = 10.0, bool calcSVD = false);
+             bool purgeOutput = false, double minColor = -10.0, double maxColor = 10.0, bool calcSVD = false,
+             double clipFraction = 0.0);
 
     Astro::outputCatalog getOutputCatalog();
 

--- a/pydir/wcsfit.cpp
+++ b/pydir/wcsfit.cpp
@@ -199,7 +199,8 @@ PYBIND11_MODULE(wcsfit, m) {
                  py::arg("minimumImprovement") = 0.02, py::arg("clipThresh") = 5.0,
                  py::arg("chisqTolerance") = 0.001, py::arg("clipEntireMatch") = false,
                  py::arg("divideInPlace") = false, py::arg("purgeOutput") = false,
-                 py::arg("minColor") = -10.0, py::arg("maxColor") = 10.0, py::arg("calcSVD") = false)
+                 py::arg("minColor") = -10.0, py::arg("maxColor") = 10.0, py::arg("calcSVD") = false,
+                 py::arg("clipFraction") = 0.0)
             .def("saveResults", &WCSFit::saveResults)
             .def("getOutputCatalog", [](WCSFit &self) {
                     Astro::outputCatalog outCat = self.getOutputCatalog();

--- a/src/subs/WCSFitRoutine.cpp
+++ b/src/subs/WCSFitRoutine.cpp
@@ -385,7 +385,8 @@ void WCSFit::setColors(const std::vector<int> &matchIDs, const std::vector<doubl
 
 void WCSFit::fit(double maxError, int minFitExposures, double reserveFraction, int randomNumberSeed,
                  double minimumImprovement, double clipThresh, double chisqTolerance, bool clipEntireMatch,
-                 bool divideInPlace, bool purgeOutput, double minColor, double maxColor, bool calcSVD) {
+                 bool divideInPlace, bool purgeOutput, double minColor, double maxColor, bool calcSVD,
+                 double clipFraction) {
     
     PROGRESS(2, Purging defective detections and matches);
 
@@ -501,7 +502,7 @@ void WCSFit::fit(double maxError, int minFitExposures, double reserveFraction, i
         oldthresh = thresh;
         // Clip entire matches on final passes if clipEntireMatch=true
         nclip = ca.sigmaClip(thresh, false, clipEntireMatch && !coarsePasses, verbose >= 1);
-        if (nclip == 0 && coarsePasses) {
+        if (nclip/double(matches.size()) > clipFraction && coarsePasses) {
             // Nothing being clipped; tighten tolerances and re-fit
             coarsePasses = false;
             ca.setRelTolerance(chisqTolerance);
@@ -526,7 +527,7 @@ void WCSFit::fit(double maxError, int minFitExposures, double reserveFraction, i
             PROGRESS(2, Purging unfittable maps);
             mapCollection.purgeInvalid();
         }
-    } while (coarsePasses || nclip > 0);
+    } while (coarsePasses || nclip/double(matches.size()) > clipFraction);
 
     // If there are reserved Matches, run sigma-clipping on them now.
     if (reserveFraction > 0.) {


### PR DESCRIPTION
The fit runs until nothing gets rejected, but this causes the fit to take (almost) forever when there are a lot of sources, because there's always something to reject.

This commit introduces a 'clipFraction' parameter, which is the minimum fraction of rejected sources that triggers a new iteration. I am setting the default to zero in order to reproduce the current behaviour, but I recommend using a value of 1.0e-2, which worked for me when processing HSC open-use data and hitting this problem.